### PR TITLE
bump deps, pin @cloudflare/vite-plugin 1.14.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-server-dom-webpack": "^19.2.0",
-    "rwsdk": "1.0.0-beta.30-test.20251119220440"
+    "rwsdk": "1.0.0-beta.31"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.15.0",
-    "@cloudflare/workers-types": "^4.20251119.0",
+    "@cloudflare/vite-plugin": "1.15.2",
+    "@cloudflare/workers-types": "^4.20251121.0",
     "@tailwindcss/vite": "^4.1.17",
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.6",
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vite": "^7.2.2",
-    "wrangler": "4.49.0"
+    "vite": "^7.2.4",
+    "wrangler": "4.50.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -18,19 +18,19 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-server-dom-webpack": "^19.2.0",
-    "rwsdk": "1.0.0-beta.24"
+    "rwsdk": "1.0.0-beta.30"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.13.18",
-    "@cloudflare/workers-types": "^4.20251014.0",
-    "@tailwindcss/vite": "^4.1.16",
-    "@types/node": "^24.10.0",
-    "@types/react": "^19.2.2",
-    "@types/react-dom": "^19.2.2",
-    "tailwindcss": "^4.1.16",
+    "@cloudflare/vite-plugin": "1.14.2",
+    "@cloudflare/workers-types": "^4.20251119.0",
+    "@tailwindcss/vite": "^4.1.17",
+    "@types/node": "^24.10.1",
+    "@types/react": "^19.2.6",
+    "@types/react-dom": "^19.2.3",
+    "tailwindcss": "^4.1.17",
     "typescript": "^5.9.3",
-    "vite": "^7.1.12",
-    "wrangler": "4.45.3"
+    "vite": "^7.2.2",
+    "wrangler": "4.49.0"
   },
   "prettier": {
     "printWidth": 100,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "rwsdk": "1.0.0-beta.30"
   },
   "devDependencies": {
-    "@cloudflare/vite-plugin": "1.14.2",
+    "@cloudflare/vite-plugin": "1.15.0",
     "@cloudflare/workers-types": "^4.20251119.0",
     "@tailwindcss/vite": "^4.1.17",
     "@types/node": "^24.10.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-server-dom-webpack": "^19.2.0",
-    "rwsdk": "1.0.0-beta.30"
+    "rwsdk": "1.0.0-beta.30-test.20251119220440"
   },
   "devDependencies": {
     "@cloudflare/vite-plugin": "1.15.0",


### PR DESCRIPTION
Encountered hang when running `pnpm dev` with latest @cloudflare/vite-plugin 1.15.0.
Pinning to v1.14.2 for now - will also ask in rwsdk.